### PR TITLE
Remove legacy tests/ directory

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,3 +1,0 @@
-module github.com/xyz/pulumi-xyz/tests/v3
-
-go 1.16


### PR DESCRIPTION
This PR removes the `tests/` directory which is no longer used. We use the `examples/` directory to run integration tests now instead.