### PR TITLE
[cleanup] Remove reference to Kubernetes provider from gen binary help info

### DIFF
--- a/provider/cmd/pulumi-gen-xyz/main.go
+++ b/provider/cmd/pulumi-gen-xyz/main.go
@@ -34,7 +34,7 @@ import (
 // TemplateDir is the path to the base directory for code generator templates.
 var TemplateDir string
 
-// BaseDir is the path to the base pulumi-provider directory.
+// BaseDir is the path to the base pulumi-xyz directory.
 var BaseDir string
 
 // Language is the SDK language.
@@ -49,7 +49,7 @@ const (
 
 func main() {
 	flag.Usage = func() {
-		const usageFormat = "Usage: %s <language> <swagger-or-schema-file> <root-pulumi-provider-dir>"
+		const usageFormat = "Usage: %s <language> <swagger-or-schema-file> <root-pulumi-xyz-dir>"
 		_, err := fmt.Fprintf(flag.CommandLine.Output(), usageFormat, os.Args[0])
 		contract.IgnoreError(err)
 		flag.PrintDefaults()

--- a/provider/cmd/pulumi-gen-xyz/main.go
+++ b/provider/cmd/pulumi-gen-xyz/main.go
@@ -34,7 +34,7 @@ import (
 // TemplateDir is the path to the base directory for code generator templates.
 var TemplateDir string
 
-// BaseDir is the path to the base pulumi-kubernetes directory.
+// BaseDir is the path to the base pulumi-provider directory.
 var BaseDir string
 
 // Language is the SDK language.
@@ -49,7 +49,7 @@ const (
 
 func main() {
 	flag.Usage = func() {
-		const usageFormat = "Usage: %s <language> <swagger-or-schema-file> <root-pulumi-kubernetes-dir>"
+		const usageFormat = "Usage: %s <language> <swagger-or-schema-file> <root-pulumi-provider-dir>"
 		_, err := fmt.Fprintf(flag.CommandLine.Output(), usageFormat, os.Args[0])
 		contract.IgnoreError(err)
 		flag.PrintDefaults()


### PR DESCRIPTION
What it says on the box. It's nice to have logical help text.