### PR TITLE
Add upgrade action example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pulumi offers this repository as a [GitHub template repository](https://docs.git
 
 1. Click "Use this template".
 1. Set the following options:
-   * Owner: pulumi 
+   * Owner: pulumi
    * Repository name: pulumi-xyz-native (replace "xyz" with the name of your provider)
    * Description: Pulumi provider for xyz
    * Repository type: Public
@@ -42,7 +42,7 @@ From the templated repository:
    ```bash
    $ make build install
    ```
-   
+
 This will:
 
 1. Create the SDK codegen binary and place it in a `./bin` folder (gitignored)
@@ -51,7 +51,7 @@ This will:
 4. Install the provider on your machine.
 
 #### Test against the example
-   
+
 ```bash
 $ cd examples/simple
 $ yarn link @pulumi/xyz
@@ -84,7 +84,7 @@ Create an example program using the resources defined in your provider, and plac
 
 You can now repeat the steps for [build, install, and test](#test-against-the-example).
 
-## Configuring CI and releases
+## Configuring CI and upgrades/ releases
 
 1. Follow the instructions laid out in the [deployment templates](./deployment-templates/README-DEPLOYMENT.md).
 

--- a/deployment-templates/README-DEPLOYMENT.md
+++ b/deployment-templates/README-DEPLOYMENT.md
@@ -10,11 +10,11 @@
 
 1. Add any needed tokens to the actions secrets for your repository or organization
 
-1. Customize the release.yml with the correct tokens using the format:  
+1. Customize the release.yml with the correct tokens using the format:
 
       `${{ secrets.MyTokenName }}`
 
-1. Customize .goreleaser.yml for your provider, replacing any instances of 'xyz' with your provider's name, and paying special attention that the ldlflags are set to match your provider/go.mod exactly: 
+1. Customize .goreleaser.yml for your provider, replacing any instances of 'xyz' with your provider's name, and paying special attention that the ldlflags are set to match your provider/go.mod exactly:
 
      `-X github.com/pulumi/pulumi-aws/provider/v5/pkg/version.Version={{.Tag}}`
 
@@ -26,3 +26,7 @@
 1. Push a tag to your repo in the format "v0.0.0" to initiate a release
 
 1. IMPORTANT: also add a tag in the format "sdk/v0.0.0" for the Go SDK
+
+# Upgrade
+
+Pulumi provides a [GitHub action](https://github.com/pulumi/pulumi-upgrade-provider-action) to automate upgrading your provider upon a new upstream version release. An example workflow that runs the upgrade action on a cron job, as well as whenever an issue is created with a title prefix of 'Upgrade terraform-provider', is [provided here](./upgrade-provider.yml).

--- a/deployment-templates/upgrade-provider.yml
+++ b/deployment-templates/upgrade-provider.yml
@@ -1,0 +1,20 @@
+name: Upgrade provider
+on:
+  issues:
+    types:
+    - opened
+  schedule:
+    - cron: '0 5 * * *'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  upgrade_provider:
+    if: contains(github.event.issue.title, 'Upgrade terraform-provider-')
+    name: upgrade-provider
+    runs-on: ubuntu-latest
+    steps:
+    - name: Call upgrade provider action
+      uses: pulumi/pulumi-upgrade-provider-action@main
+      with:
+        slack-channel: provider-upgrade-status
+        slack-webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Part of https://github.com/pulumi/upgrade-provider/issues/73
Updating the boilerplate readme with an example workflow that uses the provider upgrade action