### PR TITLE
Remove scripts folder from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ nodejs_sdk::
 	cd ${PACKDIR}/nodejs/ && \
 		yarn install && \
 		yarn run tsc && \
-		cp -R scripts/ bin && \
 		cp ../../README.md ../../LICENSE package.json yarn.lock bin/ && \
 		sed -i.bak 's/$${VERSION}/$(VERSION)/g' bin/package.json && \
 		rm ./bin/package.json.bak


### PR DESCRIPTION
I can repro the reported problem - so it sounds like it started happening before https://github.com/pulumi/pulumi-provider-boilerplate/issues/69? Is it caused by the CLI version upgrade?

Fixes https://github.com/pulumi/pulumi-provider-boilerplate/issues/70