### PR TITLE
feat: Adds a prepare target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,16 @@ prepare::
 	mv "provider/cmd/pulumi-resource-xyz" provider/cmd/pulumi-resource-${NAME} # SED_SKIP
 
 	if [[ "${OS}" != "Darwin" ]]; then \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
 	fi
 
 	# In MacOS the -i parameter needs an empty string to execute in place.
 	if [[ "${OS}" == "Darwin" ]]; then \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
 	fi
 
 ensure::

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ PROJECT_NAME := Pulumi Xyz Resource Provider
 PACK             := xyz
 PACKDIR          := sdk
 PROJECT          := github.com/pulumi/pulumi-xyz
-NODE_MODULE_NAME := @pulumi/xyz
-NUGET_PKG_NAME   := Pulumi.Xyz
+NODE_MODULE_NAME := @abc/xyz
+NUGET_PKG_NAME   := Abc.Xyz
 
 PROVIDER        := pulumi-resource-${PACK}
 VERSION         ?= $(shell pulumictl get version)
@@ -16,6 +16,30 @@ GOPATH			:= $(shell go env GOPATH)
 WORKING_DIR     := $(shell pwd)
 EXAMPLES_DIR    := ${WORKING_DIR}/examples/yaml
 TESTPARALLELISM := 4
+
+OS := $(shell uname)
+EMPTY_TO_AVOID_SED := 
+
+prepare::
+	@if test -z "${NAME}"; then echo "NAME not set"; exit 1; fi
+	@if test -z "${REPOSITORY}"; then echo "REPOSITORY not set"; exit 1; fi
+	@if test -z "${ORG}"; then echo "ORG not set"; exit 1; fi
+	@if test ! -d "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz"; then "Project already prepared"; exit 1; fi
+
+	mv "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-resource-${NAME}
+
+	if [[ "${OS}" != "Darwin" ]]; then \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i 's,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i 's/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i 's/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
+	fi
+
+	# In MacOS the -i parameter needs an empty string to execute in place.
+	if [[ "${OS}" == "Darwin" ]]; then \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' 's,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' 's/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' 's/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
+	fi
 
 ensure::
 	cd provider && go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -18,27 +18,26 @@ EXAMPLES_DIR    := ${WORKING_DIR}/examples/yaml
 TESTPARALLELISM := 4
 
 OS := $(shell uname)
-EMPTY_TO_AVOID_SED := 
 
 prepare::
 	@if test -z "${NAME}"; then echo "NAME not set"; exit 1; fi
 	@if test -z "${REPOSITORY}"; then echo "REPOSITORY not set"; exit 1; fi
 	@if test -z "${ORG}"; then echo "ORG not set"; exit 1; fi
-	@if test ! -d "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz"; then "Project already prepared"; exit 1; fi
+	@if test ! -d "provider/cmd/pulumi-resource-xyz"; then "Project already prepared"; exit 1; fi # SED_SKIP
 
-	mv "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-resource-${NAME}
+	mv "provider/cmd/pulumi-resource-xyz" provider/cmd/pulumi-resource-${NAME} # SED_SKIP
 
 	if [[ "${OS}" != "Darwin" ]]; then \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i 's,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i 's/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i 's/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
 	fi
 
 	# In MacOS the -i parameter needs an empty string to execute in place.
 	if [[ "${OS}" == "Darwin" ]]; then \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' 's,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' 's/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
-		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' 's/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s,github.com/pulumi/pulumi-[x]yz,${REPOSITORY},g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s/[xX]yz/${NAME}/g' {} \; &> /dev/null; \
+		find . \( -path './.git' -o -path './sdk' -o -path './examples' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s/[aA]bc/${ORG}/g' {} \; &> /dev/null; \
 	fi
 
 ensure::

--- a/README.md
+++ b/README.md
@@ -46,7 +46,18 @@ Pulumi offers this repository as a [GitHub template repository](https://docs.git
 
 From the templated repository:
 
-1. Search-replace `xyz` with the name of your desired provider.
+1. Run the following command to update files to use the name of your provider (third-party: use your GitHub organization/username):
+
+    ```bash
+    make prepare NAME=foo REPOSITORY=github.com/pulumi/pulumi-foo ORG=myorg
+    ```
+
+   This will do the following:
+   - rename folders in `provider/cmd` to `pulumi-resource-{NAME}`
+   - replace dependencies in `provider/go.mod` to reflect your repository name
+   - find and replace all instances of the boilerplate `xyz` with the `NAME` of your provider.
+   - find and replace all instances of the boilerplate `abc` with the `ORG` of your provider.
+   - replace all instances of the `github.com/pulumi/pulumi-xyz` repository with the `REPOSITORY` location
 
 #### Build the provider and install the plugin
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -81,7 +81,7 @@ func (Random) Create(ctx p.Context, name string, input RandomArgs, preview bool)
 
 func makeRandom(length int) string {
 	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	charset := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	charset := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") // SED_SKIP
 
 	result := make([]rune, length)
 	for i := range result {


### PR DESCRIPTION
Adds a prepare target to makefile to globally replace instances of `xyz` and `abc`. This should make it easier for users to get started. This is similar to what is done in pulumi-tf-provider-boilerplate.

It skips the sdk ~~and examples~~ directory to illustrate what needs to be changed initially.

edit: removed examples to be skipped as it is useful to rename the yaml examples file contents.