### PR TITLE
Specify bash `$(SHELL)` variable in Makefile when using `[[`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ WORKING_DIR     := $(shell pwd)
 EXAMPLES_DIR    := ${WORKING_DIR}/examples/yaml
 TESTPARALLELISM := 4
 
-OS := $(shell uname)
+OS    := $(shell uname)
+SHELL := /bin/bash
 
 prepare::
 	@if test -z "${NAME}"; then echo "NAME not set"; exit 1; fi


### PR DESCRIPTION
The Makefile utilizes a feature ,`[[`, of the Bash shell. Yet, it leaves the `SHELL` variable uninitialized, which means that [`make` will default to `sh`](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html), which does not support the bash-specific `[[` keyword.

```
$ sh -c 'type [['
[[: not found
$ bash -c 'type [['
[[ is a shell keyword
```

This results in an awkward, preventable error:

```
🐋 ❯ make prepare NAME=bar REPOSITORY=github.com/mario-campos/pulumi-bar-native ORG=mario-campos
mv "provider/cmd/pulumi-resource-xyz" provider/cmd/pulumi-resource-bar # SED_SKIP
if [[ "Linux" != "Darwin" ]]; then \
        find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s,github.com/pulumi/pulumi-[x]yz,github.com/mario-campos/pulumi-bar-native,g' {} \; &> /dev/null; \
        find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s/[xX]yz/bar/g' {} \; &> /dev/null; \
        find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '/SED_SKIP/!s/[aA]bc/mario-campos/g' {} \; &> /dev/null; \
fi
/bin/sh: 1: [[: not found
# In MacOS the -i parameter needs an empty string to execute in place.
if [[ "Linux" == "Darwin" ]]; then \
        find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s,github.com/pulumi/pulumi-[x]yz,github.com/mario-campos/pulumi-bar-native,g' {} \; &> /dev/null; \
        find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s/[xX]yz/bar/g' {} \; &> /dev/null; \
        find . \( -path './.git' -o -path './sdk' \) -prune -o -not -name 'go.sum' -type f -exec sed -i '' '/SED_SKIP/!s/[aA]bc/mario-campos/g' {} \; &> /dev/null; \
fi
/bin/sh: 1: [[: not found
```

How to fix? This PR sets the `SHELL` variable in the Makefile to `/bin/bash` to ensure that the `[[` keyword is available.