### PR TITLE
Explicitly mention that this boilerplate works for ComponentResources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pulumi Native Provider Boilerplate
 
-This repository is a boilerplate showing how to create and locally test a native Pulumi provider.
+This repository is a boilerplate showing how to create and locally test a native Pulumi provider (with examples of both CustomResource and ComponentResource [resource types](https://www.pulumi.com/docs/iac/concepts/resources/)). 
 
 ## Authoring a Pulumi Native Provider
 


### PR DESCRIPTION
We're archiving https://github.com/pulumi/pulumi-component-provider-go-boilerplate and directing users here, so we should mention Component resources in the README