### PR TITLE
Update dotnet to 8.0 LTS

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -58,7 +58,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'dotnet')
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup Python
       if: inputs.tools == 'all' || contains(inputs.tools, 'python')

--- a/examples/dotnet/provider-xyz-native.csproj
+++ b/examples/dotnet/provider-xyz-native.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/sdk/dotnet/Pulumi.Xyz.csproj
+++ b/sdk/dotnet/Pulumi.Xyz.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
This tracks the upstream changes being made in ci-mgmt, with a view to having boilerplate be managed bi ci-mgmt in future.

Note that the SDKs were not regenerated because there seems to be a lot of unrelated changes coming. 

Part of: https://github.com/pulumi/ci-mgmt/issues/1307