### PR TITLE
Fix release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ AZURE_SIGNING_KEY_VAULT_URI ?=
 SKIP_SIGNING ?=
 
 bin/jsign-6.0.jar:
+	mkdir -p bin
 	wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar --output-document=bin/jsign-6.0.jar
 
 sign-goreleaser-exe-amd64: GORELEASER_ARCH := amd64_v1


### PR DESCRIPTION
Release is failing because `bin` doesn't exist.

> release failed after 2m50s               error=post hook failed: shell: 'make sign-goreleaser-exe-amd64': exit status 2: wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar --output-document=bin/jsign-6.0.jar
bin/jsign-6.0.jar: No such file or directory
make: *** [Makefile:175: bin/jsign-6.0.jar] Error 1

Fixes https://github.com/pulumi/pulumi-provider-boilerplate/issues/181