### PR TITLE
Fix weekly pu/pu upgrade job (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ $(SCHEMA_FILE): provider $(PULUMI)
 # does not require the ability to build all SDKs.
 #
 # To build the SDKs, use `make build_sdks`
+#
+# Required by CI (weekly-pulumi-update)
 codegen: $(SCHEMA_FILE) sdk/dotnet sdk/go sdk/nodejs sdk/python sdk/java
 
 .PHONY: sdk/%
@@ -219,8 +221,8 @@ ci-mgmt: .ci-mgmt.yaml
 	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 .PHONY: ci-mgmt
 
-.PHONY: codegen
-codegen: # Required by CI
+.PHONY:local_generate
+local_generate: # Required by CI
 
 .PHONY: generate_schema
 generate_schema: ${SCHEMA_PATH} # Required by CI


### PR DESCRIPTION
> make: *** No rule to make target 'local_generate'.  Stop.

Another failure due to special-casing for command in ci-mgmt.

https://github.com/pulumi/ci-mgmt/blob/ec0100a675f385c7ec6d05c3ee7a7a63682b2a72/provider-ci/internal/pkg/templates/native/.github/workflows/weekly-pulumi-update.yml#L94-L98

Fixes #193.