### PR TITLE
Fix broken sign script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,13 +196,14 @@ sign-goreleaser-exe-arm64: GORELEASER_ARCH := arm64
 # Set the shell to bash to allow for the use of bash syntax.
 sign-goreleaser-exe-%: SHELL:=/bin/bash
 sign-goreleaser-exe-%: bin/jsign-6.0.jar
-    SKIP_SIGNING=${SKIP_SIGNING} \
+	SKIP_SIGNING=${SKIP_SIGNING} \
 	AZURE_SIGNING_CLIENT_ID=${AZURE_SIGNING_CLIENT_ID} \
 	AZURE_SIGNING_CLIENT_SECRET=${AZURE_SIGNING_CLIENT_SECRET} \
 	AZURE_SIGNING_TENANT_ID=${AZURE_SIGNING_TENANT_ID} \
 	AZURE_SIGNING_KEY_VAULT_URI=${AZURE_SIGNING_KEY_VAULT_URI} \
 	GORELEASER_ARCH=${GORELEASER_ARCH} \
-	 scripts/sign-windows-binary.sh
+	CI=${CI} \
+		scripts/sign-windows-binary.sh
 
 # To make an immediately observable change to .ci-mgmt.yaml:
 #

--- a/scripts/sign-windows-binary.sh
+++ b/scripts/sign-windows-binary.sh
@@ -13,7 +13,7 @@ fi
 if [[ "|$AZURE_SIGNING_CLIENT_ID|$AZURE_SIGNING_CLIENT_SECRET|$AZURE_SIGNING_TENANT_ID|$AZURE_SIGNING_KEY_VAULT_URI|" == *"||"* ]]; then
     >&2 echo "Can't sign windows binaries as required configuration not set: AZURE_SIGNING_CLIENT_ID, AZURE_SIGNING_CLIENT_SECRET, AZURE_SIGNING_TENANT_ID, AZURE_SIGNING_KEY_VAULT_URI";
     >&2 echo "To rebuild with signing delete the unsigned windows exe file and rebuild with the fixed configuration"; 
-    if [[ "${CI}" == "true" ]]; then 
+    if [[ "$CI" == "true" ]]; then
         >&2 echo "Signing windows binary is required in CI";
         exit 1;
     fi


### PR DESCRIPTION
* Make the `sh` script executable.
* Fix issues with tabs vs spaces on Makefile.
* Propagate CI env variable correctly.

Part of https://github.com/pulumi/pulumi-provider-boilerplate/issues/977 investigation.