### PR TITLE
Escape sign command properly

### DIFF
--- a/scripts/sign-windows-binary.sh
+++ b/scripts/sign-windows-binary.sh
@@ -26,9 +26,9 @@ file="dist/build-provider-sign-windows_windows_$GORELEASER_ARCH/pulumi-resource-
 mv "$file" "$file.unsigned";
 
 >&2 echo "Logging in to Azure";
-az login --service-principal
-    --username "$AZURE_SIGNING_CLIENT_ID"
-    --password "$AZURE_SIGNING_CLIENT_SECRET"
+az login --service-principal \
+    --username "$AZURE_SIGNING_CLIENT_ID" \
+    --password "$AZURE_SIGNING_CLIENT_SECRET" \
     --tenant "$AZURE_SIGNING_TENANT_ID";
 
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Forgot separating the commands properly with `\`. 

Part of https://github.com/pulumi/pulumi-provider-boilerplate/issues/977 investigation.

Verified workflow changes on this branch: https://github.com/pulumi/pulumi-provider-boilerplate/pull/1000
Verified workflow changes on this run: https://github.com/pulumi/pulumi-provider-boilerplate/actions/runs/20433988161/job/58711083153?pr=1000