### PR TITLE
Remove unnecessary toolchain

### DIFF
--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi-provider-boilerplate/examples/go
 
 go 1.24.7
 
-toolchain go1.24.10
-
 replace github.com/pulumi/pulumi-provider-boilerplate/sdk/go/pulumi-provider-boilerplate => ../../sdk/go/pulumi-provider-boilerplate
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi-provider-boilerplate
 
 go 1.24.7
 
-toolchain go1.24.10
-
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/pulumi/providertest v0.6.0

--- a/sdk/go/pulumi-provider-boilerplate/go.mod
+++ b/sdk/go/pulumi-provider-boilerplate/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi-provider-boilerplate/sdk/go/pulumi-provider-boil
 
 go 1.24.7
 
-toolchain go1.24.10
-
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/pulumi/pulumi/sdk/v3 v3.212.0


### PR DESCRIPTION
We're managing this toolchain with mise. The presence of this toolchain causes us to re-download Go instead of using the already installed version.