### PR TITLE
Migrate Windows code signing to Azure Trusted Signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,8 +415,10 @@ jobs:
         AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
         AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
         AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}
-        AZURE_SIGNING_KEY_VAULT_URI: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_KEY_VAULT_URI }}
-        SKIP_SIGNING: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET == '' && steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_KEY_VAULT_URI == '' }}
+        AZURE_SIGNING_ACCOUNT_ENDPOINT: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_ENDPOINT }}
+        AZURE_SIGNING_ACCOUNT_NAME: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_NAME }}
+        AZURE_SIGNING_CERT_PROFILE_NAME: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CERT_PROFILE_NAME }}
+        SKIP_SIGNING: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET == '' && steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_ENDPOINT == '' && steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_NAME == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CERT_PROFILE_NAME == '' }}
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       with:
         args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -371,8 +371,10 @@ jobs:
         AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
         AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
         AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}
-        AZURE_SIGNING_KEY_VAULT_URI: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_KEY_VAULT_URI }}
-        SKIP_SIGNING: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET == '' && steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_KEY_VAULT_URI == '' }}
+        AZURE_SIGNING_ACCOUNT_ENDPOINT: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_ENDPOINT }}
+        AZURE_SIGNING_ACCOUNT_NAME: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_NAME }}
+        AZURE_SIGNING_CERT_PROFILE_NAME: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CERT_PROFILE_NAME }}
+        SKIP_SIGNING: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET == '' && steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_ENDPOINT == '' && steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_NAME == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CERT_PROFILE_NAME == '' }}
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       with:
         args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,8 +371,10 @@ jobs:
         AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
         AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
         AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}
-        AZURE_SIGNING_KEY_VAULT_URI: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_KEY_VAULT_URI }}
-        SKIP_SIGNING: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET == '' && steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_KEY_VAULT_URI == '' }}
+        AZURE_SIGNING_ACCOUNT_ENDPOINT: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_ENDPOINT }}
+        AZURE_SIGNING_ACCOUNT_NAME: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_NAME }}
+        AZURE_SIGNING_CERT_PROFILE_NAME: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CERT_PROFILE_NAME }}
+        SKIP_SIGNING: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET == '' && steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID == '' && steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_ENDPOINT == '' && steps.esc-secrets.outputs.AZURE_SIGNING_ACCOUNT_NAME == '' && steps.esc-secrets.outputs.AZURE_SIGNING_CERT_PROFILE_NAME == '' }}
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       with:
         args: -p 3 release --clean --timeout 60m0s

--- a/Makefile
+++ b/Makefile
@@ -179,28 +179,32 @@ install_nodejs_sdk::
 test:: test_provider
 	cd examples && go test -v -tags=all -timeout 2h
 
-# Set these variables to enable signing of the windows binary
+# Set these variables to enable signing of the windows binary with Azure Trusted Signing.
 AZURE_SIGNING_CLIENT_ID ?=
 AZURE_SIGNING_CLIENT_SECRET ?=
 AZURE_SIGNING_TENANT_ID ?=
-AZURE_SIGNING_KEY_VAULT_URI ?=
+AZURE_SIGNING_ACCOUNT_ENDPOINT ?=
+AZURE_SIGNING_ACCOUNT_NAME ?=
+AZURE_SIGNING_CERT_PROFILE_NAME ?=
 SKIP_SIGNING ?=
 
-bin/jsign-6.0.jar:
+bin/jsign-7.4.jar:
 	mkdir -p bin
-	wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar --output-document=bin/jsign-6.0.jar
+	wget https://github.com/ebourg/jsign/releases/download/7.4/jsign-7.4.jar --output-document=bin/jsign-7.4.jar
 
 sign-goreleaser-exe-amd64: GORELEASER_ARCH := amd64_v1
 sign-goreleaser-exe-arm64: GORELEASER_ARCH := arm64
 
 # Set the shell to bash to allow for the use of bash syntax.
 sign-goreleaser-exe-%: SHELL:=/bin/bash
-sign-goreleaser-exe-%: bin/jsign-6.0.jar
+sign-goreleaser-exe-%: bin/jsign-7.4.jar
 	SKIP_SIGNING=${SKIP_SIGNING} \
 	AZURE_SIGNING_CLIENT_ID=${AZURE_SIGNING_CLIENT_ID} \
 	AZURE_SIGNING_CLIENT_SECRET=${AZURE_SIGNING_CLIENT_SECRET} \
 	AZURE_SIGNING_TENANT_ID=${AZURE_SIGNING_TENANT_ID} \
-	AZURE_SIGNING_KEY_VAULT_URI=${AZURE_SIGNING_KEY_VAULT_URI} \
+	AZURE_SIGNING_ACCOUNT_ENDPOINT=${AZURE_SIGNING_ACCOUNT_ENDPOINT} \
+	AZURE_SIGNING_ACCOUNT_NAME=${AZURE_SIGNING_ACCOUNT_NAME} \
+	AZURE_SIGNING_CERT_PROFILE_NAME=${AZURE_SIGNING_CERT_PROFILE_NAME} \
 	GORELEASER_ARCH=${GORELEASER_ARCH} \
 	CI=${CI} \
 		scripts/sign-windows-binary.sh

--- a/scripts/sign-windows-binary.sh
+++ b/scripts/sign-windows-binary.sh
@@ -10,9 +10,9 @@ fi
 # Only sign windows binary if fully configured.
 # Test variables set by joining with | between and looking for || showing at least one variable is empty.
 # Move the binary to a temporary location and sign it there to avoid the target being up-to-date if signing fails.
-if [[ "|$AZURE_SIGNING_CLIENT_ID|$AZURE_SIGNING_CLIENT_SECRET|$AZURE_SIGNING_TENANT_ID|$AZURE_SIGNING_KEY_VAULT_URI|" == *"||"* ]]; then
-    >&2 echo "Can't sign windows binaries as required configuration not set: AZURE_SIGNING_CLIENT_ID, AZURE_SIGNING_CLIENT_SECRET, AZURE_SIGNING_TENANT_ID, AZURE_SIGNING_KEY_VAULT_URI";
-    >&2 echo "To rebuild with signing delete the unsigned windows exe file and rebuild with the fixed configuration"; 
+if [[ "|$AZURE_SIGNING_CLIENT_ID|$AZURE_SIGNING_CLIENT_SECRET|$AZURE_SIGNING_TENANT_ID|$AZURE_SIGNING_ACCOUNT_ENDPOINT|$AZURE_SIGNING_ACCOUNT_NAME|$AZURE_SIGNING_CERT_PROFILE_NAME|" == *"||"* ]]; then
+    >&2 echo "Can't sign windows binaries as required configuration not set: AZURE_SIGNING_CLIENT_ID, AZURE_SIGNING_CLIENT_SECRET, AZURE_SIGNING_TENANT_ID, AZURE_SIGNING_ACCOUNT_ENDPOINT, AZURE_SIGNING_ACCOUNT_NAME, AZURE_SIGNING_CERT_PROFILE_NAME";
+    >&2 echo "To rebuild with signing delete the unsigned windows exe file and rebuild with the fixed configuration";
     if [[ "$CI" == "true" ]]; then
         >&2 echo "Signing windows binary is required in CI";
         exit 1;
@@ -36,20 +36,25 @@ if [[ $? -ne 0 ]]; then
     exit 1;
 fi
 
->&2 echo "Getting access token";
-ACCESS_TOKEN="$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken)";
+>&2 echo "Getting Trusted Signing access token";
+ACCESS_TOKEN="$(az account get-access-token --resource "https://codesigning.azure.net" | jq -r .accessToken)";
 
 if [[ -z "$ACCESS_TOKEN" ]]; then
     >&2 echo "Failed to get access token";
     exit 1;
 fi
 
->&2 echo "Signing $file.unsigned";
-java -jar bin/jsign-6.0.jar \
-    --storetype AZUREKEYVAULT \
-    --keystore "PulumiCodeSigning" \
-    --url "$AZURE_SIGNING_KEY_VAULT_URI" \
+# jsign expects the keystore as a bare endpoint hostname (no scheme, no trailing slash).
+ENDPOINT_HOST="${AZURE_SIGNING_ACCOUNT_ENDPOINT#https://}"
+ENDPOINT_HOST="${ENDPOINT_HOST#http://}"
+ENDPOINT_HOST="${ENDPOINT_HOST%/}"
+
+>&2 echo "Signing $file.unsigned with Azure Trusted Signing ($ENDPOINT_HOST, $AZURE_SIGNING_ACCOUNT_NAME/$AZURE_SIGNING_CERT_PROFILE_NAME)";
+java -jar bin/jsign-7.4.jar \
+    --storetype TRUSTEDSIGNING \
+    --keystore "$ENDPOINT_HOST" \
     --storepass "$ACCESS_TOKEN" \
+    --alias "$AZURE_SIGNING_ACCOUNT_NAME/$AZURE_SIGNING_CERT_PROFILE_NAME" \
     "$file.unsigned";
 
 >&2 echo "Moving $file.unsigned to $file";


### PR DESCRIPTION
## Summary

Migrates Windows binary signing from Azure Key Vault (`jsign --storetype AZUREKEYVAULT`) to [Azure Trusted Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/). The previous AKV code-signing cert expired, breaking the release pipeline. Trusted Signing issues short-lived Microsoft-managed certs so there's nothing to rotate.

- `Makefile`: declare the three new `AZURE_SIGNING_ACCOUNT_*` variables (dropping `AZURE_SIGNING_KEY_VAULT_URI`), bump `jsign` 6.0 → 7.4, pass the new vars through to the signing script.
- `scripts/sign-windows-binary.sh`: switch to `--storetype TRUSTEDSIGNING`, use the `https://codesigning.azure.net` token audience, derive the keystore host from the account endpoint, pass account/profile via `--alias`.
- `.github/workflows/{build,release,prerelease}.yml`: replace the `AZURE_SIGNING_KEY_VAULT_URI` env passthrough with the three new outputs and update the `SKIP_SIGNING` guard. These match what pulumi/ci-mgmt#2126 will regenerate once it merges, so subsequent ci-mgmt regens will be no-ops here.

Companion to pulumi/ci-mgmt#2126 and pulumi/pulumi-command#1200.

## Prerequisites (already met)

- ESC env `imports/github-secrets` already exposes `AZURE_SIGNING_ACCOUNT_ENDPOINT`, `AZURE_SIGNING_ACCOUNT_NAME`, `AZURE_SIGNING_CERT_PROFILE_NAME`.
- Signing SP has `Artifact Signing Certificate Profile Signer` on `pulumi-code-signing/pulumi-code-signing`.

## Test plan

- [ ] CI release build produces a Windows binary with a valid Trusted Signing certificate chain
